### PR TITLE
feat: 로그인시 상세페이지 조회 service 구현 [#9]

### DIFF
--- a/deal/src/main/java/com/nuguri/dealservice/controller/DealController.java
+++ b/deal/src/main/java/com/nuguri/dealservice/controller/DealController.java
@@ -31,6 +31,14 @@ public class DealController {
         );
     }
 
+    @ApiOperation(value = "로그인시 중고거래 상세페이지 조회")
+    @GetMapping("/detail/login")
+    public ResponseEntity findLoginDealDetail(@RequestParam Long memberId, @RequestParam Long dealId){
+        return ResponseEntity.status(HttpStatus.OK).body(
+                new ResponseDto(HttpStatus.OK.value(),"로그인시 중고거래 상세페이지", dealService.findLoginDealDetail(memberId, dealId))
+        );
+    }
+
     @ApiOperation(value = "중고거래 등록")
     @PostMapping("/regist")
     public ResponseEntity dealRegist(@RequestPart DealRegistRequestDto dealRegistRequestDto,

--- a/deal/src/main/java/com/nuguri/dealservice/repository/DealFavoriteRepository.java
+++ b/deal/src/main/java/com/nuguri/dealservice/repository/DealFavoriteRepository.java
@@ -4,7 +4,8 @@ import com.nuguri.dealservice.domain.DealFavorite;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface DealFavoriteRepository extends JpaRepository<DealFavorite, Long>, DealFavoriteRepositoryCustom {
-    DealFavorite findByMemberIdAndDealId(Long memberId, Long dealId);
+    Optional<DealFavorite> findByMemberIdAndDealId(Long memberId, Long dealId);
 }

--- a/deal/src/main/java/com/nuguri/dealservice/repository/DealFavoriteRepositoryCustom.java
+++ b/deal/src/main/java/com/nuguri/dealservice/repository/DealFavoriteRepositoryCustom.java
@@ -6,4 +6,5 @@ import java.util.List;
 
 public interface DealFavoriteRepositoryCustom {
     List<DealListDto> findDealByMemberIdAndIsFavorite(Long memberId);
+    boolean findIsFavoriteByMemberIdAndDealId(Long memberId, Long dealId);
 }

--- a/deal/src/main/java/com/nuguri/dealservice/repository/DealFavoriteRepositoryImpl.java
+++ b/deal/src/main/java/com/nuguri/dealservice/repository/DealFavoriteRepositoryImpl.java
@@ -40,4 +40,19 @@ public class DealFavoriteRepositoryImpl implements DealFavoriteRepositoryCustom{
                 .fetch();
         return dealListDtoList;
     }
+
+    @Override
+    public boolean findIsFavoriteByMemberIdAndDealId(Long memberId, Long dealId) {
+        Boolean isFavorite = queryFactory
+                .select(dealFavorite.isFavorite)
+                .from(dealFavorite)
+                .where(dealFavorite.memberId.eq(memberId)
+                        .and(dealFavorite.deal.id.eq(dealId)))
+                .fetchOne();
+
+        if(isFavorite == null){
+            return false;
+        }
+        return isFavorite;
+    }
 }

--- a/deal/src/test/java/com/nuguri/dealservice/repository/DealFavoriteRepositoryImplTest.java
+++ b/deal/src/test/java/com/nuguri/dealservice/repository/DealFavoriteRepositoryImplTest.java
@@ -24,4 +24,10 @@ class DealFavoriteRepositoryImplTest {
             System.out.println("dealListDto = " + dealListDto);
         }
     }
+
+    @Test
+    public void 멤버중고거래아이디로즐겨찾기() throws Exception{
+        boolean isFavoriteByMemberIdAndDealId = dealFavoriteRepository.findIsFavoriteByMemberIdAndDealId(4L, 4L);
+        System.out.println("isFavoriteByMemberIdAndDealId = " + isFavoriteByMemberIdAndDealId);
+    }
 }

--- a/deal/src/test/java/com/nuguri/dealservice/service/DealServiceTest.java
+++ b/deal/src/test/java/com/nuguri/dealservice/service/DealServiceTest.java
@@ -5,6 +5,7 @@ import com.nuguri.dealservice.dto.baseaddress.BaseAddressDto;
 import com.nuguri.dealservice.dto.category.CategoryListDto;
 import com.nuguri.dealservice.dto.deal.DealDetailDto;
 import com.nuguri.dealservice.dto.deal.DealListDto;
+import com.nuguri.dealservice.dto.deal.DealLoginDetailDto;
 import com.nuguri.dealservice.repository.DealFavoriteRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,6 +29,12 @@ class DealServiceTest {
     public void 비로그인상세페이지조회() throws Exception{
         DealDetailDto dealDetail = dealService.findDealDetail(1L);
         System.out.println("dealDetail = " + dealDetail);
+    }
+
+    @Test
+    public void 로그인상세페이지조회() throws Exception{
+        DealLoginDetailDto loginDealDetail = dealService.findLoginDealDetail(4L, 4L);
+        System.out.println("loginDealDetail = " + loginDealDetail);
     }
 
     @Test


### PR DESCRIPTION
Description
--
- close #9 

Progress
--
- feignClient로 baseAddress에서 Dong, member에서 nickname 데이터 받아서
- 기존에 monolithic때 사용한 DealLoginDetailDto 만들기
- 로그인된 사용자의 상세페이지이므로 즐겨찾기 유무까지 확인 필요
- Null인 경우 Querydsl로 체크하여 isFavorite 값 조회